### PR TITLE
feat: Add multi-OS support, Docker tests, and new README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,119 @@
-# Dotfiles
+<div align="center">
 
-Here are my dotfiles config, just to have them in one place.
+# 👨‍💻 @mrchucu1's Dotfiles
 
-A way to have same (or close to) look and feel for the terminal in different environments. Minimal configuration preferred.
+My personal configuration files for a consistent and customized development environment.
 
-## Installation
+<!-- Badges -->
+<p>
+  <img src="https://img.shields.io/github/last-commit/mrchucu1/dotfiles?style=for-the-badge&logo=github&logoColor=white&color=black" alt="Last Commit"/>
+  <img src="https://img.shields.io/badge/License-MIT-blue.svg?style=for-the-badge" alt="License: MIT"/>
+  <img src="https://img.shields.io/badge/Built%20with-Shell%20%26%20VimL-lightgrey.svg?style=for-the-badge&color=black" alt="Built with Shell & VimL"/>
+</p>
 
-### Prerequisits
-- [ZSH](https://www.zsh.org/)
-- [Oh-My-ZSH](https://ohmyz.sh/)
-- [Vim](https://www.vim.org/)
-- [tmux](https://github.com/tmux/tmux)
-- [asdf](https://github.com/asdf-vm/asdf) (Optional)
+</div>
 
+---
 
-Instaling from scrip, using `prepare.sh`, download the file beafore the repo:
+## ✨ Features
+
+This setup installs and configures a complete terminal environment with a focus on productivity for cloud-native development.
+
+*   **💻 Shell:** **Zsh** with **Oh My Zsh** for a powerful shell experience.
+    *   Includes `zsh-syntax-highlighting` and `zsh-autosuggestions` plugins.
+*   **✍️ Editor:** **Neovim** is configured as the default editor with a modern plugin set:
+    *   **`coc.nvim`** for IDE-like autocompletion and code navigation.
+    *   **`vim-fugitive`** for seamless Git integration inside Neovim.
+    *   **`fzf.vim`** for blazing-fast fuzzy file finding.
+    *   **`gruvbox`** theme for a pleasant aesthetic.
+*   **🪟 Terminal Multiplexer:** A powerful **Tmux** setup based on the popular [gpakosz/.tmux](https://github.com/gpakosz/.tmux) configuration.
+*   **📦 Version Management:** Installs **`asdf`** to easily manage multiple runtime versions (e.g., Node.js, Go).
+*   **☁️ Cloud-Native Aliases:** Includes a large set of aliases for `kubectl` and `gcloud` to speed up your workflow.
+
+---
+
+## 🛠️ One-Step Installation
+
+Run the single command for your OS to download the installer and begin the setup.
+
+### 🍎 macOS
 ```bash
-cd $HOME
-curl -OL https://raw.githubusercontent.com/mrchucu1/dotfiles/master/prepare.sh
-chmod +x prepare.sh
-./prepare.sh
+zsh -c "$(curl -fsSL https://raw.githubusercontent.com/mrchucu1/dotfiles/main/prepare.osx.sh)"
 ```
 
-## Usage
+### 🐧 Linux
 
-You can use this for a fast start on a new linux environment, or for boostraping a brand new envirnoment. The repos here are just for me to have all my configurations for my terminal on a single place for me to clone it and get started ASAP.
+#### **Ubuntu**
+```bash
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/mrchucu1/dotfiles/main/prepare.ubuntu.sh)"
+```
+
+#### **Fedora**
+```bash
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/mrchucu1/dotfiles/main/prepare.fedora.sh)"
+```
+
+#### **Arch Linux**
+```bash
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/mrchucu1/dotfiles/main/prepare.arch.sh)"
+```
+
+After the script completes, restart your terminal or log out and log back in for all changes to take effect.
+
+---
+
+## ⌨️ Keybindings & Aliases
+
+Here are some of the custom keybindings and aliases you can use after installation.
+
+<details>
+  <summary><strong>Kubernetes Aliases (using k=kubectl)</strong></summary>
+
+  | Alias   | Description                       |
+  |---------|-----------------------------------|
+  | `k`     | `kubectl`                         |
+  | `kgp`   | `kubectl get pods`                |
+  | `kl`    | `kubectl logs`                    |
+  | `klf`   | `kubectl logs -f`                 |
+  | `keti`  | `kubectl exec -ti`                |
+  | `kaf`   | `kubectl apply -f`                |
+  | `kcgc`  | `kubectl config get-contexts`     |
+  | `kcuc`  | `kubectl config use-context`      |
+  | `kcn`   | Set the namespace for the current context |
+  | `kgd`   | `kubectl get deployment`          |
+  | `kdd`   | `kubectl describe deployment`     |
+  | `krsd`  | `kubectl rollout status deployment`|
+  | `kgs`   | `kubectl get service`             |
+  | `...`   | *And many more in the `zshrc` file!*|
+</details>
+
+<details>
+  <summary><strong>Neovim Keybindings (Leader key is `<Space>`)</strong></summary>
+
+  | Keybinding      | Action                               |
+  |-----------------|--------------------------------------|
+  | **Navigation**  |                                      |
+  | `<C-p>`         | Fuzzy find Git files (fzf)           |
+  | `<Leader>pf`    | Fuzzy find files (fzf)               |
+  | `<Leader>pv`    | Open file explorer (`netrw`)         |
+  | `<Leader>h/j/k/l` | Move between window splits         |
+  | **CoC (LSP)**   |                                      |
+  | `<Leader>gd`    | Go to definition                     |
+  | `<Leader>gi`    | Go to implementation                 |
+  | `<Leader>gr`    | Find references                      |
+  | `<Leader>rr`    | Rename symbol                        |
+  | `g[` / `g]`     | Go to previous/next diagnostic       |
+  | **Fugitive (Git)**|                                      |
+  | `<Leader>gs`    | Open Git status window               |
+  | `<Leader>gh`    | `diffget` from "their" branch (merge)|
+  | `<Leader>gu`    | `diffget` from "our" branch (merge)  |
+</details>
+
+---
+
+## 🐳 Testing with Docker
+
+The `tests/` directory contains Dockerfiles to build and validate the setup for each supported Linux distribution.
 
 ## Contributing
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.

--- a/prepare.arch.sh
+++ b/prepare.arch.sh
@@ -1,0 +1,35 @@
+# !/bin/env bash
+
+#install dependencies
+sudo pacman -Syy --noconfirm tmux zsh xclip tmux git neovim alacritty fzf
+
+#Download dotfiles
+git clone https://github.com/mrchucu1/dotfiles.git $HOME/.dotfiles
+
+# Download asdf
+curl -OL https://github.com/asdf-vm/asdf/releases/download/v0.18.0/asdf-v0.18.0-linux-amd64.tar.gz
+tar -xf ./asdf-v0.18.0-linux-amd64.tar.gz -C /usr/bin
+asdf plugin add nodejs https://github.com/asdf-vm/asdf-nodejs.git
+
+# Install zsh
+git clone https://github.com/ohmyzsh/ohmyzsh.git $HOME/.dotfiles/ohmyzsh
+git clone https://github.com/zsh-users/zsh-syntax-highlighting.git $HOME/.dotfiles/ohmyzsh/plugins/zsh-syntax-highlighting
+git clone https://github.com/zsh-users/zsh-autosuggestions $HOME/.dotfiles/ohmyzsh/plugins/zsh-autosuggestions
+ln -s $HOME/.dotfiles/ohmyzsh $HOME/.oh-my-zsh
+ln -s $HOME/.dotfiles/zshrc $HOME/.zshrc
+
+#install tmux
+git clone https://github.com/gpakosz/.tmux.git $HOME/.dotfiles/.tmux
+ln -s $HOME/.dotfiles/.tmux $HOME/.tmux
+ln -s -f $HOME/.tmux/.tmux.conf $HOME/.tmux.conf
+ln -s -f $HOME/.dotfiles/tmux.conf $HOME/.tmux.conf.local
+
+#install nvim
+mkdir -p $HOME/.config/nvim
+ln -s $HOME/.dotfiles/vimrc-config $HOME/.config/nvim/init.vim
+sh -c 'curl -fLo "${XDG_DATA_HOME:-$HOME/.local/share}"/nvim/site/autoload/plug.vim --create-dirs \
+       https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim'
+
+cd $HOME && asdf install nodejs lts && asdf set nodejs lts
+##That's all falks
+echo "Thanks for using mrchucu1's dotfiles auto instalation tool."

--- a/prepare.fedora.sh
+++ b/prepare.fedora.sh
@@ -1,0 +1,38 @@
+# !/bin/bash
+
+#install dependencies
+sudo yum install -y tmux zsh xclip git neovim fzf
+
+#Download dotfiles
+git clone https://github.com/mrchucu1/dotfiles.git $HOME/.dotfiles
+
+# Download asdf
+curl -OL https://github.com/asdf-vm/asdf/releases/download/v0.18.0/asdf-v0.18.0-linux-amd64.tar.gz
+tar -xf ./asdf-v0.18.0-linux-amd64.tar.gz -C /usr/bin
+asdf plugin add nodejs https://github.com/asdf-vm/asdf-nodejs.git
+
+# Install zsh
+git clone https://github.com/ohmyzsh/ohmyzsh.git $HOME/.dotfiles/ohmyzsh
+git clone https://github.com/zsh-users/zsh-syntax-highlighting.git $HOME/.dotfiles/ohmyzsh/plugins/zsh-syntax-highlighting
+git clone https://github.com/zsh-users/zsh-autosuggestions $HOME/.dotfiles/ohmyzsh/plugins/zsh-autosuggestions
+ln -s $HOME/.dotfiles/ohmyzsh $HOME/.oh-my-zsh
+ln -s $HOME/.dotfiles/zshrc $HOME/.zshrc
+
+#install tmux
+git clone https://github.com/gpakosz/.tmux.git $HOME/.dotfiles/.tmux
+ln -s $HOME/.dotfiles/.tmux $HOME/.tmux
+ln -s -f $HOME/.tmux/.tmux.conf $HOME/.tmux.conf
+ln -s -f $HOME/.dotfiles/tmux.conf $HOME/.tmux.conf.local
+
+#install vim
+mkdir -p $HOME/.config/nvim
+ln -s $HOME/.dotfiles/vimrc-config $HOME/.config/nvim/init.vim
+sh -c 'curl -fLo "${XDG_DATA_HOME:-$HOME/.local/share}"/nvim/site/autoload/plug.vim --create-dirs \
+       https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim'
+
+cd $HOME && asdf install nodejs lts && asdf set nodejs lts
+#change shell
+chsh $USER --shell=$(which zsh)
+
+##That's all falks
+echo "Thanks for using mrchucu1's dotfiles auto instalation tool for Fedora©."

--- a/prepare.osx.sh
+++ b/prepare.osx.sh
@@ -1,0 +1,38 @@
+# !/bin/env bash
+
+#install dependencies
+brew install tmux zsh xclip asdf git neovim fzf
+
+#Download dotfiles
+git clone https://github.com/mrchucu1/dotfiles.git $HOME/.dotfiles
+
+# Download asdf
+curl -OL https://github.com/asdf-vm/asdf/releases/download/v0.18.0/asdf-v0.18.0-darwin-arm64.tar.gz
+tar -xf ./asdf-v0.18.0-darwin-arm64.tar.gz -C /usr/bin
+asdf plugin add nodejs https://github.com/asdf-vm/asdf-nodejs.git
+
+# Install zsh
+git clone https://github.com/ohmyzsh/ohmyzsh.git $HOME/.dotfiles/ohmyzsh
+git clone https://github.com/zsh-users/zsh-syntax-highlighting.git $HOME/.dotfiles/ohmyzsh/plugins/zsh-syntax-highlighting
+git clone https://github.com/zsh-users/zsh-autosuggestions $HOME/.dotfiles/ohmyzsh/plugins/zsh-autosuggestions
+ln -s $HOME/.dotfiles/ohmyzsh $HOME/.oh-my-zsh
+ln -s $HOME/.dotfiles/zshrc $HOME/.zshrc
+
+#install tmux
+git clone https://github.com/gpakosz/.tmux.git $HOME/.dotfiles/.tmux
+ln -s $HOME/.dotfiles/.tmux $HOME/.tmux
+ln -s -f $HOME/.tmux/.tmux.conf $HOME/.tmux.conf
+ln -s -f $HOME/.dotfiles/tmux.conf $HOME/.tmux.conf.local
+
+#install vim
+mkdir -p $HOME/.config/nvim
+ln -s $HOME/.dotfiles/vimrc-config $HOME/.config/nvim/init.vim
+sh -c 'curl -fLo "${XDG_DATA_HOME:-$HOME/.local/share}"/nvim/site/autoload/plug.vim --create-dirs \
+       https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim'
+
+cd $HOME && asdf install nodejs lts && asdf set nodejs lts
+#change shell
+chsh $USER --shell=$(which zsh)
+
+##That's all falks
+echo "Thanks for using mrchucu1's dotfiles auto instalation tool for Mac M series."

--- a/prepare.ubuntu.sh
+++ b/prepare.ubuntu.sh
@@ -1,0 +1,39 @@
+# !/bin/env bash
+
+#install dependencies
+sudo apt update && sudo apt install --assume-yes tmux zsh xclip git neovim
+
+#Download dotfiles
+git clone https://github.com/mrchucu1/dotfiles.git $HOME/.dotfiles
+
+# Download asdf
+curl -OL https://github.com/asdf-vm/asdf/releases/download/v0.18.0/asdf-v0.18.0-linux-amd64.tar.gz
+tar -xf ./asdf-v0.18.0-linux-amd64.tar.gz -C /usr/bin
+asdf plugin add nodejs https://github.com/asdf-vm/asdf-nodejs.git
+
+# Install zsh
+git clone https://github.com/ohmyzsh/ohmyzsh.git $HOME/.dotfiles/ohmyzsh
+git clone https://github.com/zsh-users/zsh-syntax-highlighting.git $HOME/.dotfiles/ohmyzsh/plugins/zsh-syntax-highlighting
+git clone https://github.com/zsh-users/zsh-autosuggestions $HOME/.dotfiles/ohmyzsh/plugins/zsh-autosuggestions
+ln -s $HOME/.dotfiles/ohmyzsh $HOME/.oh-my-zsh
+ln -s $HOME/.dotfiles/zshrc $HOME/.zshrc
+
+#install tmux
+git clone https://github.com/gpakosz/.tmux.git $HOME/.dotfiles/.tmux
+ln -s $HOME/.dotfiles/.tmux $HOME/.tmux
+ln -s -f $HOME/.tmux/.tmux.conf $HOME/.tmux.conf
+ln -s -f $HOME/.dotfiles/tmux.conf $HOME/.tmux.conf.local
+
+#install vim
+mkdir -p $HOME/.config/nvim
+ln -s $HOME/.dotfiles/vimrc-config $HOME/.config/nvim/init.vim
+sh -c 'curl -fLo "${XDG_DATA_HOME:-$HOME/.local/share}"/nvim/site/autoload/plug.vim --create-dirs \
+       https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim'
+
+cd $HOME && asdf install nodejs lts && asdf set nodejs lts
+
+#change shell
+chsh $USER --shell=$(which zsh)
+
+##That's all falks
+echo "Thanks for using mrchucu1's dotfiles auto instalation tool."

--- a/tests/Dockerfile.arch
+++ b/tests/Dockerfile.arch
@@ -1,0 +1,6 @@
+from archlinux
+run pacman -Syy --noconfirm curl sudo git
+copy prepare.arch.sh .
+run chmod +x ./prepare.arch.sh
+run ./prepare.arch.sh
+entrypoint /bin/zsh

--- a/tests/Dockerfile.debian
+++ b/tests/Dockerfile.debian
@@ -1,0 +1,6 @@
+from debian
+run apt update && apt install --assume-yes git sudo curl
+copy prepare.ubuntu.sh .
+run chmod +x ./prepare.ubuntu.sh
+run ./prepare.ubuntu.sh
+entrypoint /bin/zsh

--- a/tests/Dockerfile.fedora
+++ b/tests/Dockerfile.fedora
@@ -1,0 +1,6 @@
+from fedora
+run yum update && yum install -y curl sudo
+copy ./prepare.fedora.sh .
+run chmod +x ./prepare.fedora.sh
+run ./prepare.fedora.sh
+entrypoint /bin/zsh

--- a/tests/Dockerfile.ubuntu
+++ b/tests/Dockerfile.ubuntu
@@ -1,0 +1,7 @@
+
+from ubuntu
+run apt update && apt install --assume-yes git sudo curl
+copy prepare.ubuntu.sh .
+run chmod +x ./prepare.ubuntu.sh
+run ./prepare.ubuntu.sh
+entrypoint /bin/zsh

--- a/zshrc
+++ b/zshrc
@@ -89,9 +89,6 @@ export EDITOR='nvim'
 # alias ohmyzsh="mate ~/.oh-my-zsh"
 
 export PATH="$PATH:$HOME/.yarn/bin:$HOME/.config/yarn/global/node_modules/.bin:/usr/bin"
-#/home/diego/.asdf/installs/golang/1.10.310.310.310.310.310.310.310.310.310.3/go/bin:
-#export GLIDE_DIR="/home/diego/.go/bin"
-#[ -s "$GLIDE_DIR/glide" ] && \. "$GLIDE_DIR/glide"
 
 # Alias for work
 
@@ -152,16 +149,5 @@ alias kru='k rollout undo'
 # Logs
 alias kl='k logs'
 alias klf='k logs -f'
-
-# Powerline
-#powerline-daemon -q
-#. /usr/lib/python3.8/site-packages/powerline/bindings/zsh/powerline.zsh
-
-#Docker env
-#export DOCKER_HOST="tcp://192.168.0.29:2376"
-#export DOCKER_CERT_PATH="/home/mrchucu1/.minikube/certs"
-#export DOOCKER_TLS_VERIFY="1"
-
-. /home/mrchucu1/.asdf/asdf.sh
 
 [ -f ~/.fzf.zsh ] && source ~/.fzf.zsh


### PR DESCRIPTION
This commit introduces a major overhaul of the repository to support multiple operating systems and improve the overall user experience.

- Replaced the single `prepare.sh` with dedicated installation scripts for macOS, Ubuntu, Fedora, and Arch Linux.
- Added a `tests` directory with Dockerfiles to allow for automated, isolated testing of the installation on each supported Linux distribution.
- Completely redesigned the `README.md` with a modern layout, badges, one-line installation commands, and a detailed showcase of features, keybindings, and aliases.

Fixes #3
Fixes #4